### PR TITLE
fixed logs.ivr.fi typo

### DIFF
--- a/templates/user.html
+++ b/templates/user.html
@@ -76,7 +76,7 @@
                 <tr>
                     <td><strong>Logs</strong></td>
                     <td><a href="https://www.twitch.tv/popout/{{ streamer.full_name }}/viewercard/{{ user.login }}">Twitch Mod Logs</a><br>
-                        <a href="https://logs.ivr.fi/?channe={{ streamer.full_name }}&user={{ user.login }}">IVR Logs</a>
+                        <a href="https://logs.ivr.fi/?channel={{ streamer.full_name }}&username={{ user.login }}">IVR Logs</a>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
The correct URL parameters for justlog is "username=" for usernames, and "channel=" for channels

Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable
- [ ] Documentation in docs/ or install-docs/ was updated, if applicable
- [ ] I have tested all changes

<!--
Don't forget to check and reformat your code:
./scripts/reformat.sh
-->
